### PR TITLE
Fix error counts in report, add options to change thresholds

### DIFF
--- a/src/pypolca/__init__.py
+++ b/src/pypolca/__init__.py
@@ -226,12 +226,14 @@ def run(
 
     out_fasta: Path = Path(output) / f"{prefix}_corrected.fasta"
     if no_polish is False:
-        fix_consensus_from_vcf(assembly_temp, vcf, out_fasta)
+        subs, indels = fix_consensus_from_vcf(assembly_temp, vcf, out_fasta)
+    else:
+        subs, indels = 0, 0
 
     ######
     # report.py
     report_file: Path = Path(output) / f"{prefix}.report"
-    create_report(vcf, assembly_temp, report_file)
+    create_report(vcf, assembly_temp, report_file, subs, indels)
 
     # finalise
     if no_polish is False:

--- a/src/pypolca/__init__.py
+++ b/src/pypolca/__init__.py
@@ -88,6 +88,21 @@ def common_options(func):
             "-f", "--force", is_flag=True, help="Force overwrites the output directory"
         ),
         click.option(
+            "--min_alt",
+            help="Minimum alt allele count to make a change",
+            default=2,
+            show_default=True,
+        ),
+        click.option(
+            "--min_ratio",
+            help="Minimum alt allele to ref allele ratio to make a change",
+            default=2.0,
+            show_default=True,
+        ),
+        click.option(
+            "--careful", is_flag=True, help="Equivalent to --min_alt 4 --min_ratio 3"
+        ),
+        click.option(
             "-n",
             "--no_polish",
             is_flag=True,
@@ -140,6 +155,9 @@ def run(
     threads,
     output,
     force,
+    min_alt,
+    min_ratio,
+    careful,
     no_polish,
     memory_limit,
     prefix,
@@ -147,6 +165,8 @@ def run(
 ):
     """Python implementation of the POLCA polisher from MaSuRCA"""
 
+    if careful:
+        min_alt, min_ratio = 4, 3
     params = {
         "--assembly": assembly,
         "--reads1": reads1,
@@ -154,6 +174,8 @@ def run(
         "--output": output,
         "--threads": threads,
         "--force": force,
+        "--min_alt": min_alt,
+        "--min_ratio": min_ratio,
         "--memory_limit": memory_limit,
         "--no_polish": no_polish,
         "--prefix": prefix,
@@ -226,7 +248,9 @@ def run(
 
     out_fasta: Path = Path(output) / f"{prefix}_corrected.fasta"
     if no_polish is False:
-        subs, indels = fix_consensus_from_vcf(assembly_temp, vcf, out_fasta)
+        subs, indels = fix_consensus_from_vcf(
+            assembly_temp, vcf, out_fasta, min_alt, min_ratio
+        )
     else:
         subs, indels = 0, 0
 

--- a/src/pypolca/utils/fix_consensus_from_vcf.py
+++ b/src/pypolca/utils/fix_consensus_from_vcf.py
@@ -11,7 +11,9 @@ from loguru import logger
 from pypolca.utils.util import copy_file
 
 
-def fix_consensus_from_vcf(ref_contigs: Path, vcf: Path, out_fasta: Path) -> Tuple[int, int]:
+def fix_consensus_from_vcf(
+    ref_contigs: Path, vcf: Path, out_fasta: Path
+) -> Tuple[int, int]:
     """
     Fix errors in the consensus called in a VCF file by FreeBayes.
 
@@ -177,26 +179,31 @@ def edit_distance(s1, s2):
     substitutions and indels.
     """
     s1, s2 = s1.upper(), s2.upper()
-    dp = [[0 for n in range(len(s2)+1)] for m in range(len(s1)+1)]
-    for i in range(len(s1)+1):
+    dp = [[0 for n in range(len(s2) + 1)] for m in range(len(s1) + 1)]
+    for i in range(len(s1) + 1):
         dp[i][0] = i
-    for j in range(len(s2)+1):
+    for j in range(len(s2) + 1):
         dp[0][j] = j
-    for i in range(1, len(s1)+1):
-        for j in range(1, len(s2)+1):
-            cost = 0 if s1[i-1] == s2[j-1] else 1
-            dp[i][j] = min(dp[i-1][j] + 1, dp[i][j-1] + 1, dp[i-1][j-1] + cost)
+    for i in range(1, len(s1) + 1):
+        for j in range(1, len(s2) + 1):
+            cost = 0 if s1[i - 1] == s2[j - 1] else 1
+            dp[i][j] = min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost)
     subs, indels = 0, 0
     i, j = len(s1), len(s2)
     while i > 0 or j > 0:
-        if i > 0 and j > 0 and s1[i-1] != s2[j-1] and dp[i][j] == dp[i-1][j-1] + 1:
+        if (
+            i > 0
+            and j > 0
+            and s1[i - 1] != s2[j - 1]
+            and dp[i][j] == dp[i - 1][j - 1] + 1
+        ):
             subs += 1
             i -= 1
             j -= 1
-        elif i > 0 and dp[i][j] == dp[i-1][j] + 1:
+        elif i > 0 and dp[i][j] == dp[i - 1][j] + 1:
             indels += 1
             i -= 1
-        elif j > 0 and dp[i][j] == dp[i][j-1] + 1:
+        elif j > 0 and dp[i][j] == dp[i][j - 1] + 1:
             indels += 1
             j -= 1
         else:

--- a/src/pypolca/utils/fix_consensus_from_vcf.py
+++ b/src/pypolca/utils/fix_consensus_from_vcf.py
@@ -2,7 +2,7 @@
 
 import re
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Tuple
 
 from Bio import SeqIO
 from Bio.Seq import Seq
@@ -11,7 +11,7 @@ from loguru import logger
 from pypolca.utils.util import copy_file
 
 
-def fix_consensus_from_vcf(ref_contigs: Path, vcf: Path, out_fasta: Path) -> None:
+def fix_consensus_from_vcf(ref_contigs: Path, vcf: Path, out_fasta: Path) -> Tuple[int, int]:
     """
     Fix errors in the consensus called in a VCF file by FreeBayes.
 
@@ -21,7 +21,8 @@ def fix_consensus_from_vcf(ref_contigs: Path, vcf: Path, out_fasta: Path) -> Non
         out_fasta (Path): Path to the output FASTA file.
 
     Returns:
-        None
+        total_subs (int): the total number of substitution changes made
+        total_indels (int): the total number of indel changes made
     """
 
     rseq = {}
@@ -49,6 +50,7 @@ def fix_consensus_from_vcf(ref_contigs: Path, vcf: Path, out_fasta: Path) -> Non
     offsets = []
 
     total_count = 0
+    total_subs, total_indels = 0, 0
 
     # Read and process VCF file
     with open(vcf) as vcf_file:
@@ -112,6 +114,9 @@ def fix_consensus_from_vcf(ref_contigs: Path, vcf: Path, out_fasta: Path) -> Non
                     fixes.append(f[4])
                     originals.append(f[3])
                     offsets.append(int(f[1]))
+                    subs, indels = edit_distance(f[3], f[4])
+                    total_subs += subs
+                    total_indels += indels
                     total_count += 1
 
     # actually fix the report now
@@ -162,3 +167,39 @@ def fix_consensus_from_vcf(ref_contigs: Path, vcf: Path, out_fasta: Path) -> Non
         )
         # copy the reference to the output
         copy_file(ref_contigs, out_fasta)
+
+    return total_subs, total_indels
+
+
+def edit_distance(s1, s2):
+    """
+    Calculate the global edit distance between two strings, providing separate counts for
+    substitutions and indels.
+    """
+    s1, s2 = s1.upper(), s2.upper()
+    dp = [[0 for n in range(len(s2)+1)] for m in range(len(s1)+1)]
+    for i in range(len(s1)+1):
+        dp[i][0] = i
+    for j in range(len(s2)+1):
+        dp[0][j] = j
+    for i in range(1, len(s1)+1):
+        for j in range(1, len(s2)+1):
+            cost = 0 if s1[i-1] == s2[j-1] else 1
+            dp[i][j] = min(dp[i-1][j] + 1, dp[i][j-1] + 1, dp[i-1][j-1] + cost)
+    subs, indels = 0, 0
+    i, j = len(s1), len(s2)
+    while i > 0 or j > 0:
+        if i > 0 and j > 0 and s1[i-1] != s2[j-1] and dp[i][j] == dp[i-1][j-1] + 1:
+            subs += 1
+            i -= 1
+            j -= 1
+        elif i > 0 and dp[i][j] == dp[i-1][j] + 1:
+            indels += 1
+            i -= 1
+        elif j > 0 and dp[i][j] == dp[i][j-1] + 1:
+            indels += 1
+            j -= 1
+        else:
+            i -= 1
+            j -= 1
+    return subs, indels

--- a/src/pypolca/utils/fix_consensus_from_vcf.py
+++ b/src/pypolca/utils/fix_consensus_from_vcf.py
@@ -37,7 +37,7 @@ def fix_consensus_from_vcf(
             if line.startswith(">"):
                 if seq:
                     rseq[ctg] = seq
-                ctg = line[1:]
+                ctg = line[1:].split()[0]
                 seq = ""
             else:
                 seq += line

--- a/src/pypolca/utils/fix_consensus_from_vcf.py
+++ b/src/pypolca/utils/fix_consensus_from_vcf.py
@@ -12,7 +12,11 @@ from pypolca.utils.util import copy_file
 
 
 def fix_consensus_from_vcf(
-    ref_contigs: Path, vcf: Path, out_fasta: Path
+    ref_contigs: Path,
+    vcf: Path,
+    out_fasta: Path,
+    min_alt: int,
+    min_ratio: float,
 ) -> Tuple[int, int]:
     """
     Fix errors in the consensus called in a VCF file by FreeBayes.
@@ -111,12 +115,14 @@ def fix_consensus_from_vcf(
 
             # append if meets criteria for POLCA
             ff = f[9].split(":")
-            if int(ff[5]) > 1:
-                if int(ff[5]) >= 2 * int(ff[3]):
-                    fixes.append(f[4])
-                    originals.append(f[3])
+            ref_count, alt_count = int(ff[3]), int(ff[5])
+            ref_seq, alt_seq = f[3], f[4]
+            if alt_count >= min_alt:
+                if alt_count >= min_ratio * ref_count:
+                    fixes.append(alt_seq)
+                    originals.append(ref_seq)
                     offsets.append(int(f[1]))
-                    subs, indels = edit_distance(f[3], f[4])
+                    subs, indels = edit_distance(ref_seq, alt_seq)
                     total_subs += subs
                     total_indels += indels
                     total_count += 1

--- a/src/pypolca/utils/report.py
+++ b/src/pypolca/utils/report.py
@@ -5,48 +5,9 @@ from Bio import SeqIO
 from loguru import logger
 
 
-def create_report(vcf: Path, genome: Path, report_file: Path) -> None:
+def create_report(vcf: Path, genome: Path, report_file: Path, numsub: int, nind: int) -> None:
     with open(vcf, "r") as file:
         lines = file.readlines()
-
-    # subs
-    numsub = 0
-    for line in lines:
-        if not line.startswith("#"):
-            fields = line.strip().split("\t")
-            if len(fields[3]) == 1 and len(fields[4]) == 1:
-                parts = fields[9].split(":")
-                if int(parts[3]) == 0 and int(parts[5]) > 1:
-                    # parts[3] is the number of reads supporting the ref
-                    # parts[5] is the number of reads supporting the alternative
-                    numsub += 1
-
-    # index
-
-    # Initialize variables
-    nind = 0
-
-    # Iterate through the lines and perform the desired operations
-    for line in lines:
-        # Skip lines starting with #
-        if not line.startswith("#"):
-            # Split the line using whitespace
-            fields = line.split()
-            # Check if the fourth and fifth fields have length greater than 1
-
-            if len(fields[3]) > 1 or len(fields[4]) > 1:
-                parts = fields[9].split(":")
-                # sometimes the record field has multiple alleles (which are not changed by Polca) so int(parts[5]) returns a Valueerror.
-                # in Awk it is not done as a loop but as a pipe as below. It will not count that line
-                # NUMIND=`grep --text -v '^#' $BASM.vcf  |perl -ane '{if(length($F[3])>1 || length($F[4])>1){$nerr=abs(length($F[3])-length($F[4]));print "$F[9]:$nerr\n";}}' | awk -F ':' 'BEGIN{nerr=0}{if($4==0 && $6>1) nerr+=$NF}END{print nerr}'`
-                # line 62 of fix_consensus_from_vcf.py deals with this in the actual polishing case
-                try:
-                    if int(parts[3]) == 0 and int(parts[5]) > 1:
-                        nind += abs(len(fields[3]) - len(fields[4]))
-                except ValueError:
-                    continue
-
-    # Print the result
 
     total_size = 0
     for record in SeqIO.parse(genome, "fasta"):

--- a/src/pypolca/utils/report.py
+++ b/src/pypolca/utils/report.py
@@ -5,7 +5,9 @@ from Bio import SeqIO
 from loguru import logger
 
 
-def create_report(vcf: Path, genome: Path, report_file: Path, numsub: int, nind: int) -> None:
+def create_report(
+    vcf: Path, genome: Path, report_file: Path, numsub: int, nind: int
+) -> None:
     with open(vcf, "r") as file:
         lines = file.readlines()
 


### PR DESCRIPTION
Hi, George!

I was running pypolca, and I noticed a small bug: the reported error counts were wrong. I vaguely recall seeing this in POLCA too, so I think it might be an old bug that got translated from Bash to Python.

As an example, I ran pypolca on a genome and it made 91 substitution changes and 5 indel changes. But the output says no changes:
```
2024-01-12 10:36:38.525 | INFO     | pypolca.utils.report:create_report:64 - Stats BEFORE polishing:
2024-01-12 10:36:38.525 | INFO     | pypolca.utils.report:create_report:66 - Substitution Errors Found: 0
2024-01-12 10:36:38.525 | INFO     | pypolca.utils.report:create_report:68 - Insertion/Deletion Errors Found: 0
2024-01-12 10:36:38.526 | INFO     | pypolca.utils.report:create_report:70 - Assembly Size: 5209984
2024-01-12 10:36:38.526 | INFO     | pypolca.utils.report:create_report:72 - Consensus Quality Before Polishing: 100.0
2024-01-12 10:36:38.526 | INFO     | pypolca.utils.report:create_report:74 - Consensus QV Before Polishing: 100.0
```

The problem seems to be that the `fix_consensus_from_vcf.py` and `report.py` files have different ways of counting errors. In `fix_consensus_from_vcf.py`, the criteria for making a change is that the alt allele needs to occur at least once and be at least twice as common as the ref allele. But in `report.py`, the criteria for counting a change is that the alt allele needs to occur at least once and the ref allele must not occur at all. Also, multi-base substitutions seem to be ignored by `report.py`.

To fix this, I just had the `fix_consensus_from_vcf.py` count substitution and indel changes as it makes them (using an edit distance algorithm to compare the before and after sequences). That way, all of the error-counting code in `report.py` could be removed.

I've done a few tests on my end, and it looks okay, but let me know if you need me to change anything!

Ryan